### PR TITLE
Dockerfile: Update nginx to 1.18.0-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:1.17.9-alpine
+FROM nginx:1.18.0-alpine
 
 ADD default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION

Image **nginx** updated from 1.17.9-alpine to 1.18.0-alpine

**Image:** [nginx](https://hub.docker.com/r/library/nginx/)  
**Version:** 1.17.9-alpine &rarr; 1.18.0-alpine  
**Dockerfile:** Dockerfile  
**Related PR:** https://github.com/treyssatvincent/docker-php-nginx-dev/pull/3

If you need help or something went wrong, please comment here while mentioning me (@DockerUpBot) or use the [support formular](https://dockerup.net/support?repo=0d9d711d-3a9c-4c52-ba9f-524c43fabe50).

<hr>
<p align="center">
  <a href="https://dockerup.net"><img align="center" src="https://dockerup.net/img/logo.svg" alt="Docker Up" width="200px"></a>
<br>
Automated <b>Dockerfile</b> updates
</p>
	